### PR TITLE
added public target-includes that provide the proper include paths fo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,6 +100,7 @@ if(ENABLE_STATIC)
     set_target_properties(lzo_static_lib PROPERTIES OUTPUT_NAME lzo2)
     target_include_directories(lzo_static_lib PUBLIC
       ${CMAKE_CURRENT_SOURCE_DIR}/minilzo
+      ${CMAKE_CURRENT_SOURCE_DIR}/include
       ${CMAKE_CURRENT_SOURCE_DIR}/include/lzo
       )
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ file(GLOB lzo_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*.c")
 list(SORT lzo_SOURCES)
 
 # LZO library
+
 if(NOT DEFINED lzo_USE_OBJECT_LIB)
     if(ENABLE_STATIC AND ENABLE_SHARED)
         if(CMAKE_POSITION_INDEPENDENT_CODE OR MSVC)
@@ -97,6 +98,10 @@ if(ENABLE_STATIC)
         list(APPEND lzo_COMPILE_TARGETS lzo_static_lib)
     endif()
     set_target_properties(lzo_static_lib PROPERTIES OUTPUT_NAME lzo2)
+    target_include_directories(lzo_static_lib PUBLIC
+      ${CMAKE_CURRENT_SOURCE_DIR}/minilzo
+      ${CMAKE_CURRENT_SOURCE_DIR}/include/lzo
+      )
 endif()
 if(ENABLE_SHARED)
     if(lzo_USE_OBJECT_LIB)


### PR DESCRIPTION
Adding "modern cmake"-style target-includes for the static minilzo library, such that any project using this as a git submodule will automatically import the proper directories when linking to this library.

This allows the parent CMakeLists.txt to simply do the following:
    add_subdirectory(<whereeverTheSubModuleMayBe>/lzo)
    ....
    target_link_libraries(myLib PUBLIC lzo_static_lib)

include paths will then automatically get imported through the static-lib's target includes.