### PR TITLE
lzotest: Fix potential handle leak in process_file() function

### DIFF
--- a/lzotest/lzotest.c
+++ b/lzotest/lzotest.c
@@ -1076,6 +1076,9 @@ compress_overrun:
                 printf("  compression overwrite error in block %lu "
                        "(%lu %lu %lu %lu)\n",
                        blocks, (unsigned long)c_len, (unsigned long)d_len, (unsigned long)bl, (unsigned long)block_c.len);
+                if (fp_dump) {
+                    (void) fclose(fp_dump); fp_dump = NULL;
+                }
                 return EXIT_LZO_ERROR;
             }
 


### PR DESCRIPTION
File descriptor `fp_dump`, created at lzotest.c:1006 lost at lzotest.c:1079 when return from function. Added close for descriptor.

Found by static analyzer Svace.